### PR TITLE
Add simple Flask interface for Meta Ads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,97 @@
+import os
+import requests
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from facebook_business.api import FacebookAdsApi
+from facebook_business.adobjects.adaccount import AdAccount
+
+# Configurations
+ACCESS_TOKEN = os.environ.get('FB_ACCESS_TOKEN')
+AD_ACCOUNT_ID = os.environ.get('FB_AD_ACCOUNT_ID')  # Format: 'act_<ID>'
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///ads.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class AdMedia(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    brand = db.Column(db.String(128))
+    media_type = db.Column(db.String(32))
+    start_date = db.Column(db.String(32))
+    end_date = db.Column(db.String(32))
+    file_path = db.Column(db.String(256))
+    ad_id = db.Column(db.String(64))
+
+# Initialize DB
+with app.app_context():
+    db.create_all()
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/download', methods=['POST'])
+def download():
+    brand = request.form['brand']
+    start_date = request.form['start_date']
+    end_date = request.form['end_date']
+    media_type = request.form['media_type']
+
+    if not ACCESS_TOKEN or not AD_ACCOUNT_ID:
+        return 'Configurez FB_ACCESS_TOKEN et FB_AD_ACCOUNT_ID', 500
+
+    FacebookAdsApi.init(access_token=ACCESS_TOKEN)
+    account = AdAccount(AD_ACCOUNT_ID)
+
+    fields = ['id', 'adcreatives']
+    params = {
+        'time_range': {'since': start_date, 'until': end_date},
+        'effective_status': ['ACTIVE', 'ARCHIVED'],
+    }
+
+    ads = account.get_ads(fields=fields, params=params)
+
+    for ad in ads:
+        creatives = ad['adcreatives']
+        for creative in creatives:
+            creative_id = creative['id']
+            creative_data = AdAccount(AD_ACCOUNT_ID).get_ad_creatives(
+                fields=['object_story_spec'], params={'id': creative_id}
+            )
+            story = creative_data[0].get('object_story_spec', {})
+            attachments = (
+                story.get('video_data')
+                or story.get('link_data')
+                or story.get('image_data')
+            )
+            if not attachments:
+                continue
+
+            media_url = attachments.get('url') or attachments.get('video_url')
+            file_path = None
+            if media_url:
+                os.makedirs('media', exist_ok=True)
+                file_name = f"{ad['id']}_{os.path.basename(media_url)}"
+                file_path = os.path.join('media', file_name)
+                try:
+                    resp = requests.get(media_url)
+                    with open(file_path, 'wb') as f:
+                        f.write(resp.content)
+                except Exception:
+                    file_path = None
+
+            entry = AdMedia(
+                brand=brand,
+                media_type=media_type,
+                start_date=start_date,
+                end_date=end_date,
+                file_path=file_path,
+                ad_id=ad['id'],
+            )
+            db.session.add(entry)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ openpyxl==3.1.2
 tqdm==4.66.4
 statsmodels==0.14.2
 httpx==0.28.1
+flask_sqlalchemy==3.1.1
+facebook_business==15.0.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Meta Ad Downloader</title>
+</head>
+<body>
+    <h1>Choisissez des critères</h1>
+    <form action="/download" method="post">
+        <label>Marque:</label>
+        <input type="text" name="brand" required><br>
+        <label>Début:</label>
+        <input type="date" name="start_date" required><br>
+        <label>Fin:</label>
+        <input type="date" name="end_date" required><br>
+        <label>Type de média (image, video):</label>
+        <input type="text" name="media_type" required><br>
+        <input type="submit" value="Télécharger">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask application to query the Meta Ads API
- provide HTML form for choosing brand, date range and media type
- download ad media and save path in a SQLite DB
- include facebook_business and flask_sqlalchemy in requirements

## Testing
- `pip install -q -r requirements.txt`
- `python app.py` (started server without errors)

------
https://chatgpt.com/codex/tasks/task_e_688b8296aa60832399802ed1cf2c59c1